### PR TITLE
Expose cwr by default.

### DIFF
--- a/bundle-local.yaml
+++ b/bundle-local.yaml
@@ -10,6 +10,7 @@ services:
       - "0"
   cwr:
     charm: "/home/ubuntu/charms/builds/cwr"
+    expose: true
     annotations:
       gui-x: "300"
       gui-y: "400"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10,6 +10,7 @@ services:
       - "0"
   cwr:
     charm: "cs:~juju-solutions/cwr"
+    expose: true
     annotations:
       gui-x: "300"
       gui-y: "400"


### PR DESCRIPTION
We need to talk to port 5000 for the webhooks, so cwr should be exposed.

@johnsca @kwmonroe @ktsakalozos 